### PR TITLE
Follow best practices for ftplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Features
 --------
 - Syntax highlighting
 - Show trailing whitespace
-- Indent-based folding
+- Indent-based folding: enable with `let g:nestedtext_folding = 1` in your
+  vimrc
 
 Feedback
 --------

--- a/ftplugin/nestedtext.vim
+++ b/ftplugin/nestedtext.vim
@@ -1,6 +1,14 @@
-set list
-set listchars=tab:→\ ,trail:·
-set foldmethod=indent
-set formatoptions+=r
-set commentstring=#\ %s
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
 
+setlocal expandtab
+setlocal formatoptions+=r
+setlocal comments=:#
+setlocal commentstring=#\ %s
+let b:undo_ftplugin = 'setlocal et< fo< comments< cms<'
+if get(g:, 'nestedtext_folding', 0)
+  setlocal foldmethod=indent
+  let b:undo_ftplugin .= ' fdm<'
+endif


### PR DESCRIPTION
Hi, thanks for creating this! The rationale for my changes is in the commit message. If you feel strongly that `foldmethod=indent` is a good default, I could toggle it to opt-out rather than opt-in.