### PR TITLE
Provide default shiftwidth, with opt-out

### DIFF
--- a/ftplugin/nestedtext.vim
+++ b/ftplugin/nestedtext.vim
@@ -4,10 +4,13 @@ endif
 let b:did_ftplugin = 1
 
 setlocal expandtab
+if get(g:, 'nestedtext_recommended_style', 1)
+  setlocal softtabstop=4 shiftwidth=4
+endif
 setlocal formatoptions+=r
 setlocal comments=:#
 setlocal commentstring=#\ %s
-let b:undo_ftplugin = 'setlocal et< fo< comments< cms<'
+let b:undo_ftplugin = 'setlocal et< sw< sts< fo< comments< cms<'
 if get(g:, 'nestedtext_folding', 0)
   setlocal foldmethod=indent
   let b:undo_ftplugin .= ' fdm<'


### PR DESCRIPTION
I went with a value of 4 here to match the default rendering of `nestedtext.dump()`.  Since the spec stops short of endorsing a preferred indentation width, it's extremely debatable whether it is appropriate to include this, but I figured it's probably better than the default of 8 one would otherwise get. As a NestedText maintainer you're in a better place than I to make the call. No skin off my back if this is rejected.

This follows the precedent set by many of Vim's included runtime files (e.g., [Python](https://github.com/vim/vim/blob/873f8243f6feadec72d9bf6203e550cc1b66611a/runtime/ftplugin/python.vim#L117-L120)).