### PR TITLE
Automatically start next item in a list

### DIFF
--- a/ftdetect/nestedtext.vim
+++ b/ftdetect/nestedtext.vim
@@ -1,1 +1,4 @@
-autocmd BufNewFile,BufRead *.nt set filetype=nestedtext
+autocmd BufNewFile,BufRead *.nt set filetype=nestedtext comments=:#,b:>,b:-
+    " the comments option causes vim to add "# ", "> " or "- " on lines 
+    " following a line with the same leading characters, which allows you easily 
+    " to continue comments, multiline strings and lists.

--- a/ftdetect/nestedtext.vim
+++ b/ftdetect/nestedtext.vim
@@ -1,4 +1,1 @@
-autocmd BufNewFile,BufRead *.nt set filetype=nestedtext comments=:#,b:>,b:-
-    " the comments option causes vim to add "# ", "> " or "- " on lines 
-    " following a line with the same leading characters, which allows you easily 
-    " to continue comments, multiline strings and lists.
+autocmd BufNewFile,BufRead *.nt set filetype=nestedtext

--- a/ftplugin/nestedtext.vim
+++ b/ftplugin/nestedtext.vim
@@ -8,7 +8,10 @@ if get(g:, 'nestedtext_recommended_style', 1)
   setlocal softtabstop=4 shiftwidth=4
 endif
 setlocal formatoptions+=r
-setlocal comments=:#,b:>,b::
+setlocal comments=:#,b:>,b:-,b::
+    " the comments option causes vim to add "# ", "> ", "- ", or ": " on lines 
+    " following a line with the same leading characters, which allows you easily 
+    " to continue comments, multiline strings, lists and multiline keys.
 setlocal commentstring=#\ %s
 let b:undo_ftplugin = 'setlocal et< sw< sts< fo< comments< cms<'
 if get(g:, 'nestedtext_folding', 0)


### PR DESCRIPTION
The vim comments option causes vim to add "# ", "> ", "- ", or ": " on linesfollowing a line with the same leading characters, which allows you easily to continue comments, multiline strings, lists and multiline keys.